### PR TITLE
ci: bump codeql-action to v4.37.3 atomically (init + analyze + upload-sarif)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,13 @@ jobs:
           python tools/generate_sbom.py --check
 
   # Dependency-vulnerability audit of every service's pinned requirements.txt.
-  # This deliberately replaces what Dependabot's PRs used to signal (Dependabot
-  # is disabled by owner decision -- no auto-bump PRs): a known CVE in a pinned
-  # dependency fails CI loudly instead of silently aging. Fixing it is a manual,
-  # reviewed version bump, which is exactly the point.
+  # Dependabot IS enabled (.github/dependabot.yml, pip + github-actions) -- an
+  # earlier version of this comment said it was disabled by owner decision,
+  # which stopped being true when that config landed. The two are
+  # complementary, not redundant: Dependabot opens PRs when a NEWER version
+  # exists, this job fails CI when a PINNED version has a known CVE, which is
+  # the case that would otherwise sit and age quietly if nobody merges the
+  # bump. Fixing either is still a manual, reviewed version bump.
   pip-audit:
     runs-on: ubuntu-latest
     steps:
@@ -189,14 +192,15 @@ jobs:
       # above from being unfalsifiable.
       - name: fire_check boundary-probe sensitivity (blocking -- a green negative must be able to go red)
         run: python eval/attack/test_fire_check.py
-      # NOTE: not SHA-pinned like this file's other actions (checkout/setup-
-      # python/gitleaks-action/actionlint) -- this was authored offline with
-      # no way to verify a real commit SHA for actions/upload-artifact, and
-      # the actionlint job's own docstring exists precisely because a wrong/
-      # unresolvable pin here would ship broken and sit undetected. Pin this
-      # to a verified SHA before relying on it in a security-sensitive context.
+      # Now SHA-pinned like this file's other actions. It was previously left
+      # on a floating tag with a NOTE saying it had been authored offline with
+      # no way to verify a real commit SHA -- that blocker is gone: the pin
+      # below is `refs/tags/v7.0.1` on actions/upload-artifact, resolved and
+      # checked against the tag rather than copied from a release page. The
+      # same SHA already pins this action in fuzz.yml and scorecard.yml, so
+      # all three now agree.
       - name: Upload Navigator layer artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: attack-navigator-layers
           path: eval/attack/out/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,10 +23,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-      - uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26  # v3
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           languages: python
           queries: security-extended
-      - uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26  # v3
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26  # v3
+      - uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What this PR does

Supersedes #26 and #30.

Dependabot splits a codeql-action bump into one PR per sub-action path, but `codeql.yml`'s `init` and `analyze` must move **together**. #26 bumped only `init`, leaving `analyze` on the v3 SHA, and the analyze job failed:

```
CodeQL job status was configuration error
...
The following actions target Node.js 20 ...:
  github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26   <- still v3
```

This moves all three references in one commit. **This PR's own `analyze` job is the proof** — the thing neither #26 nor #30 could provide.

### On the pin

`v4.37.3` is an **annotated** tag, so `refs/tags/v4.37.3` resolves to the tag object `c54b30b7…` while the peeled commit is `e4fba868…` — the latter is what belongs in a `uses:`. Verified with `git ls-remote`, as were the three already-merged bumps (#27, #28, #29). Every pin in every workflow was re-checked against its trailing comment:

| Action | Tag | Pinned commit |
|---|---|---|
| `github/codeql-action` | v4.37.3 | `e4fba868…` ✅ |
| `actions/upload-artifact` | v7.0.1 | `043fb46d…` ✅ |
| `actions/setup-python` | v7.0.0 | `5fda3b95…` ✅ |
| `gitleaks/gitleaks-action` | v3.0.0 | `e0c47f4f…` ✅ |

Trailing comments updated from `# v3` to `# v4.37.3`. Under SHA pinning that comment is the only human-readable record of what is pinned, so a stale one is worse than none.

### Two adjacent fixes

**`ci.yml`'s last floating action reference is now pinned.** `actions/upload-artifact` was left on a tag with a NOTE explaining it had been authored offline with no way to verify a real commit SHA. That blocker is gone, and the same v7.0.1 commit already pins this action in `fuzz.yml` and `scorecard.yml`. Every action in every workflow is now SHA-pinned — `grep -rn "uses: [^@]*@v[0-9]" .github/workflows/` returns nothing.

**A stale comment on the `pip-audit` job** claimed Dependabot is "disabled by owner decision — no auto-bump PRs". `.github/dependabot.yml` has since landed and is what opened these five PRs. The two are complementary, not redundant: Dependabot fires when a *newer* version exists, `pip-audit` fires when a *pinned* version has a known CVE — the case that otherwise ages quietly if nobody merges the bump.

## Residual risk (stated, not hidden)

`scorecard.yml` triggers on `schedule`, `push: [main]`, and `branch_protection_rule` — **not** `pull_request`. So its `upload-sarif` line is still not exercised by this PR's checks and will first run on merge to `main`. That's the reason #30 was held on its own; it's bundled here because it is the *same commit* that `init` and `analyze` are proven on by this PR's analyze job, which is materially better evidence than #30 had alone. Adding a `pull_request` trigger to that workflow would be the wrong fix — it publishes results with `publish_results: true` and `id-token: write`.

## Related issue

Supersedes #26, #30.

## Type of change

- [x] Bug fix
- [ ] New parser (new log source)
- [ ] Feature / enhancement (v0.1 scope)
- [x] Docs / infra / developer experience
- [ ] Other:

## Verification

- [x] `make test` (i.e. `./run_all_tests.sh`) passes locally — `ALL TESTS PASS`.
- [ ] For a parser: n/a
- [x] New behavior is covered by a contract test or sample — n/a for a workflow pin; the coverage here is CI itself, specifically the `analyze` job that #26 turned red.

```
all workflows parse OK
=== any remaining floating (non-SHA) action refs? ===
  none - every action is SHA-pinned
=== pins vs comments ===
  OK  github/codeql-action@v4.37.3 == e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
  OK  actions/upload-artifact@v7.0.1 == 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
  OK  actions/setup-python@v7.0.0 == 5fda3b95a4ea91299a34e894583c3862153e4b97
  OK  gitleaks/gitleaks-action@v3.0.0 == e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e

ALL TESTS PASS
```

## Checklist

- [x] One logical change (no unrelated refactors bundled in).
- [x] I did not hand-set `type_uid` (it's derived via `base_event()`) — no parser code touched.
- [x] Output still validates against Contract A (OCSF) — no pipeline code touched.
- [x] No real secrets, credentials, or real PII/IPs committed.
- [x] Status claims are accurate — the unexercised `upload-sarif` path is called out above rather than described as verified.
- [x] No rule files added or changed.
- [x] By submitting, I agree my contribution is licensed under Apache-2.0 (LICENSE).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMAmtRQkETtp8Ly6Dv6X6w)_