### PR TITLE
docs(readme): drop "OpenSearch, not Elastic" as a differentiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,30 @@ never leaves your network.**
 
 FENGARDE ingests logs from multiple sources, normalizes them to a single schema
 ([OCSF](https://schema.ocsf.io/)), runs correlation rules over a sliding window,
-and surfaces alerts in a dashboard. Every service is independent and talks to the
-rest of the system only through a message bus, so you can scale or replace any
-piece without rewriting the others.
+and surfaces alerts in a dashboard. Storage is OpenSearch. Every service is
+independent and talks to the rest of the system only through a message bus, so
+you can scale or replace any piece without rewriting the others.
 
 Three things make it different from a generic self-hosted SIEM:
 
 - **OCSF-native, not retrofitted.** Every source normalizes to the same open
-  schema from day one — instrument once, stay portable, no vendor log-format
-  lock-in.
-- **OpenSearch, not Elastic.** No license asterisk on the storage engine — the
-  open-source story has no fine print.
+  schema from day one, so one rule covers every source that emits the event —
+  an SSH login, a Windows login and an Active Directory login are one
+  brute-force detection, not three. Instrument once, stay portable, no vendor
+  log-format lock-in.
+- **OT and IT in one pipeline.** OPC UA and Modbus/TCP normalize into the same
+  OCSF schema as Active Directory, Windows and your firewall, so the plant floor
+  runs through the same detection engine, dashboard and report path as the
+  office network — not a second toolchain.
 - **AI triage that never leaves your network.** Local Ollama by default, with a
   documented stub fallback — your alert data is never piped through a
   third-party LLM API.
+
+> **On OpenSearch vs. Elastic:** storing in OpenSearch means there is no license
+> asterisk on the storage engine ([ADR 003](docs/adr/003-opensearch-not-elasticsearch.md)),
+> which is worth knowing but is *not* a differentiator against the comparison
+> people actually make — Wazuh's indexer is an OpenSearch fork too. It only
+> distinguishes FENGARDE from Elastic-based stacks, so it is not listed above.
 
 New in v0.4: parser packs for the sources this wedge actually needs — MCP/AI-agent
 tool-call audit logs, industrial OPC UA control-system events, and n8n automation-platform


### PR DESCRIPTION
## What this PR does

Opens a PR for a commit that was sitting on an unmerged branch with no PR. The change was a deliberate positioning decision, confirmed by the maintainer, not an abandoned draft.

Replaces "OpenSearch, not Elastic" in the three-differentiators list with **"OT and IT in one pipeline"**, and demotes the OpenSearch point to a note that states plainly why it isn't a differentiator: Wazuh's indexer is an OpenSearch fork too, so it only distinguishes FENGARDE from *Elastic-based* stacks, not from the comparison people actually make. The licensing rationale stays, linked to [ADR 003](docs/adr/003-opensearch-not-elasticsearch.md) — verified present on `main`.

Also sharpens the OCSF-native bullet with the concrete consequence (one brute-force rule covering SSH, Windows and AD logins rather than three) and states "Storage is OpenSearch" plainly in the intro, where it belongs as a fact rather than a selling point.

This is the same honest-status discipline `SSOT.md` §2 applies to capability claims, pointed at marketing copy: a true statement that doesn't survive the comparison a reader will actually make is not a differentiator.

## Related issue

n/a

## Type of change

- [ ] New parser (new log source)
- [ ] Bug fix
- [ ] Feature / enhancement (v0.1 scope)
- [x] Docs / infra / developer experience
- [ ] Other:

## Verification

- [x] `make test` (i.e. `./run_all_tests.sh`) passes — README-only change, no code touched.
- [ ] For a parser: n/a
- [x] New behavior is covered by a contract test or sample — n/a, documentation only.

```
README.md only; merges cleanly onto current main (0 conflict markers).
Link target docs/adr/003-opensearch-not-elasticsearch.md confirmed present.
```

## Checklist

- [x] One logical change (no unrelated refactors bundled in).
- [x] I did not hand-set `type_uid` — no parser code touched.
- [x] Output still validates against Contract A (OCSF) — no pipeline code touched.
- [x] No real secrets, credentials, or real PII/IPs committed.
- [x] Status claims are accurate — this PR removes a claim precisely because it overstated a differentiator.
- [x] No rule files added or changed.
- [x] By submitting, I agree my contribution is licensed under Apache-2.0 (LICENSE).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMAmtRQkETtp8Ly6Dv6X6w)_