### PR TITLE
fix(fire_check): non-zero rule-count floor, plus a harness attribution canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Harness liveness canary** in `eval/attack/fire_check.py`: a synthetic,
+  unconditionally-satisfiable rule (empty selection, no field/time/fixture
+  dependency) replayed against every real fixture event *before* any rule
+  result is reported — `main()` exits 1 and reports **the harness** as broken
+  rather than printing rule numbers over a dead pipeline. Motivated by the 14
+  stateless rules, which have no boundary probe and therefore no equivalent of
+  the stateful positive replay proving the harness can still fire anything:
+  without this, "correctly untested" and "silently stopped testing" printed
+  identically for all 14. It does **not** close the stateless boundary gap
+  (that still needs hand-authored per-rule near-miss fixtures) — it separates
+  two failure modes that were indistinguishable from outside. Verified to go
+  red on both an empty fixture pipeline and a regressed `Rule.evaluate()`.
+
 - **Action-pin gate** (`tools/verify_action_pins.py`, blocking in CI and in
   `run_all_tests.sh`): every `uses:` in every workflow must be SHA-pinned, and
   any trailing `# vX.Y.Z` comment must actually resolve upstream to the pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Harness liveness canary** in `eval/attack/fire_check.py`: a synthetic,
-  unconditionally-satisfiable rule (empty selection, no field/time/fixture
-  dependency) replayed against every real fixture event *before* any rule
-  result is reported — `main()` exits 1 and reports **the harness** as broken
-  rather than printing rule numbers over a dead pipeline. Motivated by the 14
-  stateless rules, which have no boundary probe and therefore no equivalent of
-  the stateful positive replay proving the harness can still fire anything:
-  without this, "correctly untested" and "silently stopped testing" printed
-  identically for all 14. It does **not** close the stateless boundary gap
-  (that still needs hand-authored per-rule near-miss fixtures) — it separates
-  two failure modes that were indistinguishable from outside. Verified to go
-  red on both an empty fixture pipeline and a regressed `Rule.evaluate()`.
+- **Non-zero rule-count floor** in `eval/attack/fire_check.py` and
+  `tools/check_rule_producers.py`: both gates passed while examining **zero
+  rules**. Every check in either is vacuously true over an empty set, so a
+  rule set that failed to load printed `[OK] all 0 rules ...` and exited 0 —
+  with the event-side counts still large and convincing (`32 events, 83 paths,
+  297 (path,value) pairs checked`). Reachable without anyone noticing:
+  `load_rules()` on a missing directory returns `[]` without raising,
+  `_contracts_dir()` falls through to a path that need not exist, and renaming
+  the `mitre:` key would make every rule skip the tagged-rule filter. This is
+  the genuine "the suite silently stopped testing anything" failure, and a
+  one-line count floor is the only thing that catches it.
+- **Harness attribution canary** in `eval/attack/fire_check.py`: a synthetic,
+  unconditionally-satisfiable rule replayed against every fixture event before
+  any rule result is reported; on failure `main()` exits 1 blaming **the
+  harness** and overwrites the JSON artifact so a stale green report cannot be
+  read as current. Scope, corrected by adversarial review after the first
+  version of this entry overstated it: this does **not** close a detection
+  blind spot. A dead fixture pipeline or broken `Rule.evaluate()` *already*
+  turned the gate red — all 26 tagged rules, including the 14 stateless ones,
+  must fire or `main()` returns 1. What it buys is attribution: without it a
+  dead harness reports "26 rule(s) ... never fire -- a real defect
+  (dead-on-arrival detection)", sending someone to hunt 26 rule bugs that do
+  not exist. It also does not catch *partial* harness death (a degraded
+  `enrich()`, one parser dropping out of `_REGISTRY`), where it stays green
+  while real rules are falsely accused — documented in its docstring rather
+  than left to be discovered.
 
 - **Action-pin gate** (`tools/verify_action_pins.py`, blocking in CI and in
   `run_all_tests.sh`): every `uses:` in every workflow must be SHA-pinned, and

--- a/eval/attack/fire_check.py
+++ b/eval/attack/fire_check.py
@@ -60,6 +60,18 @@ field match is the entire rest of the value space, so no near-miss fixture
 is generatable and each one has to be hand-authored. They are reported as
 untested rather than counted as passing.
 
+**Liveness canary (`_canary_check`).** Since the 14 stateless rules get NO
+boundary probe at all, they have no equivalent of the stateful positive
+replay proving the harness can still make a rule fire -- "untested" and "the
+harness silently stopped running" would print identically for every one of
+them. `main()` runs a synthetic, unconditionally-satisfiable rule (empty
+selection, matches any event, no field/time dependency) against every real
+fixture event BEFORE reporting any rule result, and refuses to report
+anything if it fails. This does not close the stateless boundary gap --
+it still needs per-rule hand-authored near-miss fixtures -- but it separates
+two failure modes that currently look identical from outside: "the rule is
+fine and untested" vs. "the measurement stopped being possible."
+
 Run: python eval/attack/fire_check.py
      make attack-scorecard   (fire_check runs alongside coverage_layer.py)
 """
@@ -81,7 +93,7 @@ sys.path.insert(0, str(ROOT / "tools"))
 from parsers import _REGISTRY  # noqa: E402
 from enrichment import enrich  # noqa: E402
 from main import Detector  # noqa: E402  -- ws4-detection's real Detector
-from engine import _time_outside_hours  # noqa: E402  -- reuse the engine's own predicate
+from engine import _time_outside_hours, Rule  # noqa: E402  -- reuse the engine's own predicate
 import check_rule_producers as crp  # noqa: E402  -- reuse the same FIXTURES
 
 OUT_DIR = Path(__file__).resolve().parent / "out"
@@ -116,6 +128,58 @@ def _real_events() -> list[dict]:
             if event is not None:
                 events.append(enrich(event))
     return events
+
+
+# A synthetic rule, never loaded from contracts/rules/*.yml, that exists only
+# to answer one question: is this HARNESS still alive? An empty selection
+# (`{}`) matches unconditionally in Rule._selection_matches -- the for loop
+# over its (zero) keys never runs, so it returns True regardless of the
+# event's shape or content. No field, no time-of-day, no fixture-specific
+# dependency of any kind: this must fire on every event, on every run,
+# forever, or something below Rule.evaluate() itself has broken.
+_CANARY_RULE_RAW = {
+    "id": "firecheck-canary-0000-not-a-real-rule",
+    "title": "[internal] fire_check liveness canary -- not a MITRE-tagged rule",
+    "level": "info",
+    "detection": {"always": {}, "condition": "always"},
+    "siem": {},
+}
+
+
+def _canary_check(events: list[dict]) -> tuple[bool, str]:
+    """Liveness probe for the harness itself, independent of any real rule's
+    condition or threshold.
+
+    Exists specifically for the 14 stateless MITRE-tagged rules, which have
+    NO boundary probe of any kind (see _boundary_probe's stateless branch) --
+    without something like this, "untested" and "the harness silently stopped
+    running" print as the identical result. A rule-content bug can only ever
+    be found by testing that rule; a harness-liveness bug can be caught once,
+    here, for every rule this file will never be able to boundary-test.
+
+    Two failure conditions, both real and both distinct from "a rule is
+    dead": the fixture loader returned nothing (`_real_events()` empty --
+    parser registry broken, fixtures dict empty, enrich() raising), or the
+    canary itself did not fire on some real event (Rule construction changed
+    shape, `_selection_matches`/`_eval_condition` regressed, `evaluate()`
+    itself broke). Either one invalidates every other result in this run,
+    which is why main() checks this FIRST and refuses to report rule results
+    if it fails -- a "12/12 held" printed alongside a dead harness is worse
+    than no number at all.
+
+    Deliberately independent of `_oh_anchors`/wall-clock machinery. A canary
+    that could itself flake on the wrong minute would just relocate the exact
+    confusion (real defect vs. harness artifact) it exists to eliminate --
+    see this file's own clock-skew history above for why that risk is not
+    theoretical here."""
+    if not events:
+        return False, "no real fixture events were loaded at all -- the fixture pipeline itself is broken"
+    canary = Rule(dict(_CANARY_RULE_RAW))
+    if not all(canary.evaluate(ev) for ev in events):
+        return False, ("the unconditionally-satisfiable canary rule did not fire on every "
+                       "real fixture event -- Rule.evaluate() or the fixture pipeline has "
+                       "regressed, independent of any real MITRE-tagged rule")
+    return True, f"canary fired on all {len(events)} real fixture event(s)"
 
 
 def _outside_hours_specs(rule) -> list[tuple[str, dict]]:
@@ -432,6 +496,15 @@ def _boundary_probe(rule, base_event: dict | None, blocked: bool = False) -> dic
 
 def main() -> int:
     events = _real_events()
+
+    canary_ok, canary_note = _canary_check(events)
+    print(f"harness liveness canary -- {canary_note}")
+    if not canary_ok:
+        print(f"\n[FAIL] HARNESS ITSELF is broken, not any real rule: {canary_note}")
+        print("       Every result below would be meaningless -- not reported.")
+        return 1
+    print()
+
     detector = Detector(plugin_rule_dirs=[])
 
     results = []

--- a/eval/attack/fire_check.py
+++ b/eval/attack/fire_check.py
@@ -60,17 +60,23 @@ field match is the entire rest of the value space, so no near-miss fixture
 is generatable and each one has to be hand-authored. They are reported as
 untested rather than counted as passing.
 
-**Liveness canary (`_canary_check`).** Since the 14 stateless rules get NO
-boundary probe at all, they have no equivalent of the stateful positive
-replay proving the harness can still make a rule fire -- "untested" and "the
-harness silently stopped running" would print identically for every one of
-them. `main()` runs a synthetic, unconditionally-satisfiable rule (empty
-selection, matches any event, no field/time dependency) against every real
-fixture event BEFORE reporting any rule result, and refuses to report
-anything if it fails. This does not close the stateless boundary gap --
-it still needs per-rule hand-authored near-miss fixtures -- but it separates
-two failure modes that currently look identical from outside: "the rule is
-fine and untested" vs. "the measurement stopped being possible."
+**Two harness-integrity guards, doing different jobs.**
+
+`main()` refuses to report `[OK]` over an empty result set (the count floor).
+Every check in this file is vacuously true over zero rules, so a rule set
+that failed to load would otherwise print "all 0 MITRE-tagged rules fire"
+and exit 0. That is the real "the suite silently stopped testing anything"
+failure, and only a count floor catches it -- the canary below is GREEN
+throughout it, because the fixtures and the evaluate() path are both healthy;
+it is the rules that vanished.
+
+`_canary_check` is about ATTRIBUTION, not detection. A dead fixture pipeline
+already turned this gate red before it existed (all 26 tagged rules must
+fire, including the 14 stateless ones -- so those DO have a blocking positive
+replay of their own, contrary to this docstring's first version). What the
+canary changes is that the failure reads "the harness is broken" instead of
+"26 rules are dead-on-arrival". See its own docstring for what it does not
+cover -- notably partial harness death, where it stays green.
 
 Run: python eval/attack/fire_check.py
      make attack-scorecard   (fire_check runs alongside coverage_layer.py)
@@ -137,6 +143,19 @@ def _real_events() -> list[dict]:
 # event's shape or content. No field, no time-of-day, no fixture-specific
 # dependency of any kind: this must fire on every event, on every run,
 # forever, or something below Rule.evaluate() itself has broken.
+#
+# KNOWN COUPLING, deliberate: this shape depends on the engine's empty-dict
+# asymmetry -- an empty SELECTION matches everything (fail open) while an
+# empty OPERATOR dict returns False (fail closed, _operator_matches). The
+# repo's own tools/validate_rules.py rejects this shape for real rule files
+# ("an empty selection matches EVERY event") and documents itself as
+# "deliberately stricter than the runtime here", i.e. the runtime behaviour
+# this canary relies on is already flagged as unintended. If the engine is
+# ever hardened to fail closed on an empty selection -- a defensible change
+# -- this canary goes permanently red and blocks the whole attack-scorecard
+# job. That is loud and correctly attributed, not silent, but whoever makes
+# that change must update this fixture (give it a selection that matches a
+# field every fixture provably emits) rather than deleting the canary.
 _CANARY_RULE_RAW = {
     "id": "firecheck-canary-0000-not-a-real-rule",
     "title": "[internal] fire_check liveness canary -- not a MITRE-tagged rule",
@@ -147,19 +166,39 @@ _CANARY_RULE_RAW = {
 
 
 def _canary_check(events: list[dict]) -> tuple[bool, str]:
-    """Liveness probe for the harness itself, independent of any real rule's
-    condition or threshold.
+    """ATTRIBUTION probe for the harness itself, independent of any real
+    rule's condition or threshold.
 
-    Exists specifically for the 14 stateless MITRE-tagged rules, which have
-    NO boundary probe of any kind (see _boundary_probe's stateless branch) --
-    without something like this, "untested" and "the harness silently stopped
-    running" print as the identical result. A rule-content bug can only ever
-    be found by testing that rule; a harness-liveness bug can be caught once,
-    here, for every rule this file will never be able to boundary-test.
+    **What this is and is not.** An adversarial review corrected the original
+    claim here, which was wrong and is worth recording: this does NOT close a
+    detection blind spot, because there was no blind spot of that shape. Every
+    one of the 26 tagged rules -- including all 14 stateless ones -- must fire
+    on its own fixture or `main()` returns 1 at `tagged_not_firing`. So the
+    stateless rules DO have a blocking positive replay of their own, and a
+    dead fixture pipeline or a broken `Rule.evaluate()` already turned the
+    gate red before this function existed. Verified by bypassing the canary
+    and re-running: exit 1, no "N/N held" line, in every such scenario.
+
+    What it actually buys is ATTRIBUTION, the same class of fix as
+    `harness_blocked`: without it a dead harness reports "26 rule(s) declare a
+    MITRE technique but never fire -- a real defect (dead-on-arrival
+    detection)", sending someone to hunt 26 rule bugs that do not exist. With
+    it, the run says the harness is broken and refuses to print rule results
+    at all. Cheaper to read, and it cannot be mistaken for a rule regression.
+
+    **It does not catch partial harness death, and that is the likelier
+    regression.** If `enrich()` degrades events instead of raising, or one
+    parser drops out of `_REGISTRY` while the rest still work, this canary
+    stays GREEN (it fires on any event, by design -- that is what keeps it
+    flake-free) while real rules are falsely accused of being dead. In that
+    scenario the report is arguably worse than without it: a confident
+    all-clear beside false accusations. The genuine "suite tested nothing"
+    failure -- zero rules reaching the loop -- is caught by the non-zero
+    count floor in `main()`, not by this function.
 
     Two failure conditions, both real and both distinct from "a rule is
     dead": the fixture loader returned nothing (`_real_events()` empty --
-    parser registry broken, fixtures dict empty, enrich() raising), or the
+    total registry death, fixtures dict empty, enrich() raising), or the
     canary itself did not fire on some real event (Rule construction changed
     shape, `_selection_matches`/`_eval_condition` regressed, `evaluate()`
     itself broke). Either one invalidates every other result in this run,
@@ -174,7 +213,11 @@ def _canary_check(events: list[dict]) -> tuple[bool, str]:
     theoretical here."""
     if not events:
         return False, "no real fixture events were loaded at all -- the fixture pipeline itself is broken"
-    canary = Rule(dict(_CANARY_RULE_RAW))
+    # deepcopy, not dict(): a shallow copy shares `detection`/`siem` with the
+    # module-level template, and this repo already contains the write pattern
+    # that would poison it for the rest of the process (test_fire_check.py
+    # does rule.raw.setdefault("detection", {})[...] = ... on a real rule).
+    canary = Rule(copy.deepcopy(_CANARY_RULE_RAW))
     if not all(canary.evaluate(ev) for ev in events):
         return False, ("the unconditionally-satisfiable canary rule did not fire on every "
                        "real fixture event -- Rule.evaluate() or the fixture pipeline has "
@@ -502,6 +545,14 @@ def main() -> int:
     if not canary_ok:
         print(f"\n[FAIL] HARNESS ITSELF is broken, not any real rule: {canary_note}")
         print("       Every result below would be meaningless -- not reported.")
+        # Overwrite the artifact rather than leaving the previous run's green
+        # JSON on disk to be read as current. "Refuses to report" has to mean
+        # the stale report stops being believable, not just that we skip a
+        # print -- a developer with a red terminal and a green fire_check.json
+        # is exactly the ambiguity this whole file exists to remove.
+        OUT_DIR.mkdir(parents=True, exist_ok=True)
+        (OUT_DIR / "fire_check.json").write_text(json.dumps(
+            {"harness_ok": False, "reason": canary_note, "results": []}, indent=2))
         return 1
     print()
 
@@ -545,6 +596,22 @@ def main() -> int:
     out_path = OUT_DIR / "fire_check.json"
     out_path.write_text(json.dumps(results, indent=2))
     print(f"\nwrote {out_path}")
+
+    # The actual "the suite silently stopped testing anything" failure, and
+    # the one the canary does NOT catch: zero rules reached the loop at all.
+    # Reachable without anyone noticing -- main.py::_contracts_dir() falls
+    # through to a path that need not exist, load_rules() on a missing
+    # directory returns [] without raising, and a rename of the `mitre:` key
+    # would make every rule skip the `continue` above. Every downstream check
+    # is vacuously true over an empty list, so the run prints "all 0 rules
+    # fire" and exits 0. A count floor is the only thing that catches it.
+    if not results:
+        print("\n[FAIL] ZERO MITRE-tagged rules were checked -- every result below "
+              "is vacuously true over an empty set. The rule set did not load, or "
+              "no rule carries a `mitre:` block any more (schema rename?). This is "
+              "the suite having stopped testing anything, which passes every other "
+              "check in this file.")
+        return 1
 
     if harness_blocked:
         print(f"\n[FAIL] {len(harness_blocked)} rule(s) could not be exercised by "

--- a/eval/attack/test_fire_check.py
+++ b/eval/attack/test_fire_check.py
@@ -28,6 +28,7 @@ Run: python eval/attack/test_fire_check.py
 from __future__ import annotations
 
 import contextlib
+import copy
 import io
 import sys
 import tempfile
@@ -416,6 +417,99 @@ def test_stateless_rules_are_reported_untested_not_passing():
           f"{stateless.id}: stateless rule produced probe verdicts it cannot support")
 
 
+def _run_main_capturing() -> tuple[int, str]:
+    """main() with stdout captured and the JSON artifact redirected to a temp
+    dir, so a test can never overwrite eval/attack/out/fire_check.json."""
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        real_out, fc.OUT_DIR = fc.OUT_DIR, Path(tmp)
+        try:
+            with contextlib.redirect_stdout(buf):
+                rc = fc.main()
+        finally:
+            fc.OUT_DIR = real_out
+    return rc, buf.getvalue()
+
+
+def test_gate_fails_when_zero_rules_are_checked():
+    """The real 'the suite silently stopped testing anything' failure.
+
+    Every check in main() is vacuously true over an empty result list, so
+    without a count floor the run prints "all 0 MITRE-tagged rules fire" and
+    exits 0 -- and the liveness canary is GREEN throughout, because the
+    fixtures and the evaluate() path are both fine. It is the rule set that
+    vanished. Reachable in practice: load_rules() on a missing directory
+    returns [] without raising, and a rename of the `mitre:` key would make
+    every rule skip the tagged-rule filter."""
+    real_detector = fc.Detector
+
+    class NoRules(real_detector):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.rules = []
+
+    fc.Detector = NoRules
+    try:
+        rc, out = _run_main_capturing()
+    finally:
+        fc.Detector = real_detector
+    check(rc == 1,
+          f"gate exited {rc} having checked ZERO rules -- a suite that tests "
+          f"nothing must not pass")
+    check("ZERO MITRE-tagged rules were checked" in out,
+          "gate did not explain that zero rules were checked")
+
+
+def test_gate_fails_when_every_rule_loses_its_mitre_block():
+    """Same blind spot by a different route: the rules load fine but no longer
+    carry a `mitre:` block (schema key renamed), so every one is skipped by
+    the tagged-rule filter and the results list is empty."""
+    real_detector = fc.Detector
+
+    class Untagged(real_detector):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            for r in self.rules:
+                r.raw = {k: v for k, v in r.raw.items() if k != "mitre"}
+
+    fc.Detector = Untagged
+    try:
+        rc, out = _run_main_capturing()
+    finally:
+        fc.Detector = real_detector
+    check(rc == 1,
+          f"gate exited {rc} when no rule carried a mitre: block -- zero rules "
+          f"were actually checked")
+    check("ZERO MITRE-tagged rules were checked" in out,
+          "gate did not explain that zero rules were checked")
+
+
+def test_canary_is_green_while_zero_rules_are_checked():
+    """Pins the canary's real scope, so nobody re-derives the claim this
+    replaced: the canary passes in the zero-rule scenario. It probes the
+    EVENT side of the harness, never the rule side. The count floor is what
+    catches that failure; the canary is for attribution."""
+    ok, _ = fc._canary_check(events())
+    check(ok is True,
+          "canary should be green with a healthy fixture pipeline regardless "
+          "of how many rules loaded -- if this changed, the scope note in "
+          "_canary_check's docstring is now wrong")
+
+
+def test_canary_does_not_mutate_the_shared_template():
+    """`Rule(dict(template))` is a SHALLOW copy sharing `detection`/`siem`.
+    Nothing mutates them today, but this repo already contains the write
+    pattern that would (rule.raw.setdefault("detection", {})[...] = ...), and
+    a poisoned template would silently change the canary for the whole
+    process."""
+    before = copy.deepcopy(fc._CANARY_RULE_RAW)
+    r = fc.Rule(copy.deepcopy(fc._CANARY_RULE_RAW))
+    r.raw.setdefault("detection", {})["injected"] = {"x": 1}
+    check(fc._CANARY_RULE_RAW == before,
+          f"constructing a canary and writing to its raw mutated the shared "
+          f"template: {fc._CANARY_RULE_RAW}")
+
+
 def test_canary_fires_on_the_real_fixture_set():
     """The liveness canary must pass on the tree as it stands -- otherwise it
     is not a canary, it is a permanently-red light nobody will look at."""
@@ -500,6 +594,10 @@ def main():
     test_overrun_replay_always_lands_past_its_window()
     test_replay_reports_a_fire_on_any_event_not_just_the_last()
     test_stateless_rules_are_reported_untested_not_passing()
+    test_gate_fails_when_zero_rules_are_checked()
+    test_gate_fails_when_every_rule_loses_its_mitre_block()
+    test_canary_is_green_while_zero_rules_are_checked()
+    test_canary_does_not_mutate_the_shared_template()
     test_canary_fires_on_the_real_fixture_set()
     test_canary_detects_an_empty_fixture_pipeline()
     test_canary_detects_a_broken_evaluate_path()

--- a/eval/attack/test_fire_check.py
+++ b/eval/attack/test_fire_check.py
@@ -416,6 +416,71 @@ def test_stateless_rules_are_reported_untested_not_passing():
           f"{stateless.id}: stateless rule produced probe verdicts it cannot support")
 
 
+def test_canary_fires_on_the_real_fixture_set():
+    """The liveness canary must pass on the tree as it stands -- otherwise it
+    is not a canary, it is a permanently-red light nobody will look at."""
+    ok, note = fc._canary_check(events())
+    check(ok is True, f"canary failed on the real fixture set: {note}")
+
+
+def test_canary_detects_an_empty_fixture_pipeline():
+    """The failure this exists for: the fixture loader silently returns
+    nothing. Every rule would then be 'untested' or 'silent' and look exactly
+    like today's honest 14-stateless-untested result."""
+    ok, note = fc._canary_check([])
+    check(ok is False,
+          "canary passed on an EMPTY fixture set -- it cannot detect the "
+          "fixture pipeline going dark, which is its entire purpose")
+    check("no real fixture events" in note,
+          f"canary gave a misleading reason for an empty fixture set: {note}")
+
+
+def test_canary_detects_a_broken_evaluate_path():
+    """The other failure: fixtures load fine but Rule.evaluate() regressed.
+    Constructed by making the canary's own evaluate() return False, which is
+    what a regression below the rule layer would look like from here."""
+    real_rule_cls = fc.Rule
+
+    class DeadRule(real_rule_cls):
+        def evaluate(self, event):
+            return False
+
+    fc.Rule = DeadRule
+    try:
+        ok, note = fc._canary_check(events())
+    finally:
+        fc.Rule = real_rule_cls
+    check(ok is False,
+          "canary passed while Rule.evaluate() returned False for everything "
+          "-- it cannot detect the evaluation path going dark")
+    check("canary rule did not fire" in note,
+          f"canary gave a misleading reason for a dead evaluate(): {note}")
+
+
+def test_canary_is_independent_of_event_content():
+    """A canary that depends on fixture shape would flake as parsers evolve
+    and get misread as 'a rule broke'. It must fire on anything, including an
+    empty dict -- no field, no timestamp, no tenant."""
+    canary = fc.Rule(dict(fc._CANARY_RULE_RAW))
+    for shape in ({}, {"x": 1}, {"time": 0}, {"src_endpoint": {"ip": "1.2.3.4"}}):
+        check(canary.evaluate(shape) is True,
+              f"canary failed to fire on {shape!r} -- it has an accidental "
+              f"dependency on event content and will flake")
+    check(canary.stateful is False,
+          "canary became stateful -- it would then depend on window/threshold "
+          "state and stop being a pure liveness signal")
+
+
+def test_canary_is_not_mistaken_for_a_real_tagged_rule():
+    """It must never be counted in the MITRE numbers it exists to protect."""
+    check(not isinstance(fc._CANARY_RULE_RAW.get("mitre"), dict),
+          "canary carries a mitre: block and would be counted as a real "
+          "tagged rule in the scorecard")
+    rules = fresh_rules()
+    check(fc._CANARY_RULE_RAW["id"] not in rules,
+          "canary id collides with a real rule loaded from contracts/rules/")
+
+
 def main():
     rules = fresh_rules()
     for rid in (RULE_BRUTE, RULE_MASS_CARD):
@@ -435,6 +500,11 @@ def main():
     test_overrun_replay_always_lands_past_its_window()
     test_replay_reports_a_fire_on_any_event_not_just_the_last()
     test_stateless_rules_are_reported_untested_not_passing()
+    test_canary_fires_on_the_real_fixture_set()
+    test_canary_detects_an_empty_fixture_pipeline()
+    test_canary_detects_a_broken_evaluate_path()
+    test_canary_is_independent_of_event_content()
+    test_canary_is_not_mistaken_for_a_real_tagged_rule()
 
     if FAILS:
         print(f"[FAIL] eval/attack/fire_check.py boundary probes: {len(FAILS)} problem(s)")

--- a/tools/check_rule_producers.py
+++ b/tools/check_rule_producers.py
@@ -308,7 +308,21 @@ def main() -> int:
                 print(f"      {p}")
         return 1
 
-    print(f"[OK] all {len(list(RULES_DIR.glob('*.yml')))} rules are satisfiable by a "
+    # Non-zero floor. Every check above is vacuously true over an empty rule
+    # set, and the event-side numbers below stay large and convincing while
+    # zero rules were actually examined -- pointed at an empty RULES_DIR this
+    # printed "[OK] all 0 rules are satisfiable ... (32 events, 83 paths, 297
+    # (path,value) pairs checked)" and exited 0. Same blind spot as
+    # eval/attack/fire_check.py's, and the same one-line fix.
+    checked = len(list(RULES_DIR.glob("*.yml")))
+    if not checked:
+        print(f"[FAIL] ZERO rule files were checked in {RULES_DIR} -- the anti-dormancy "
+              f"gate passed without examining a single rule. Every check above is "
+              f"vacuously true over an empty set; the event-side counts below say "
+              f"nothing about rule coverage.")
+        return 1
+
+    print(f"[OK] all {checked} rules are satisfiable by a "
           f"real event that both matches them and carries their group/distinct "
           f"fields ({len(events)} events, {len(all_paths)} paths, "
           f"{len(all_pairs)} (path,value) pairs checked)")


### PR DESCRIPTION
## What this PR does

Two harness-integrity guards doing different jobs. The PR started as just the canary; adversarial review showed the canary's stated purpose was wrong and that the failure it was commissioned to catch leaves it **green**. Both the code and the claims are corrected below.

### 1. Non-zero rule-count floor — the actual fix

Both `eval/attack/fire_check.py` and `tools/check_rule_producers.py` **passed while examining zero rules**. Every check in either is vacuously true over an empty set:

```
harness liveness canary -- canary fired on all 32 real fixture event(s)
MITRE empirical firing check -- 0 tagged rule(s) checked ...
[OK] all 0 MITRE-tagged rules fire on their own real producer fixture     exit 0
```

```
[OK] all 0 rules are satisfiable by a real event ...
     (32 events, 83 paths, 297 (path,value) pairs checked)                exit 0
```

Note the event-side numbers stay large and convincing while nothing is checked. Reachable without anyone noticing: `load_rules()` on a missing directory returns `[]` without raising, `main.py::_contracts_dir()` falls through to a path that need not exist, and renaming the `mitre:` key would make every rule skip the tagged-rule filter. **This is the genuine "the suite silently stopped testing anything" failure**, and a one-line count floor is the only thing that catches it.

### 2. Harness attribution canary — corrected scope

A synthetic, unconditionally-satisfiable rule replayed against every fixture event before any rule result is reported; on failure `main()` exits 1 blaming the harness and overwrites the JSON artifact so a stale green report can't read as current.

**What the first version of this PR claimed, and why it was wrong.** It said a dead harness would keep printing `12/12 held; 14 untested`, and that the 14 stateless rules had no equivalent of the stateful positive replay. Both false. All 26 tagged rules — stateless included — must fire or `main()` returns 1 at `tagged_not_firing`, so the stateless rules have a blocking positive replay of their own. Verified by bypassing the canary and re-running:

| scenario | pre-canary exit | printed "N/N held"? |
|---|---|---|
| fixture pipeline dead | **1** | no |
| `Rule.evaluate()` always False | **1** | no |
| all 14 stateless rules stop matching | **1** | no |

So the canary never turns a green run red. What it buys is **attribution**: without it a dead harness reports *"26 rule(s) declare a MITRE technique but never fire — a real defect (dead-on-arrival detection)"*, sending someone to hunt 26 rule bugs that don't exist. Same class as the earlier `harness_blocked` fix.

**What it does not cover, disclosed rather than left to be found:** *partial* harness death. If `enrich()` degrades events instead of raising, or one parser drops out of `_REGISTRY`, the canary stays green while real rules are falsely accused — arguably a worse report than without it. That's inherent to being content-independent, which is what keeps it flake-free, so it's documented in the docstring.

### Also from the review

- `deepcopy` instead of `dict()` for the canary template — the shallow copy shared `detection`/`siem` with the module-level dict, and this repo already contains the write pattern (`rule.raw.setdefault("detection", {})[...] = ...`) that would poison it process-wide.
- Documented the deliberate coupling to the engine's empty-selection fail-open, which `tools/validate_rules.py` already rejects for real rules while calling itself *"deliberately stricter than the runtime here"*. Hardening the runtime would turn the canary permanently red — whoever does that must update the fixture, not delete the canary.

## Verification

| Scenario | Result |
|---|---|
| zero rules reach the loop | ✅ exit 1, "ZERO MITRE-tagged rules were checked" |
| every rule loses its `mitre:` block | ✅ exit 1, same floor |
| `check_rule_producers.py` on empty rules dir | ✅ exit 1 (was: `[OK] all 0 rules`, exit 0) |
| canary green while zero rules checked | ✅ pinned by test, so the scope note can't silently rot |
| empty fixture pipeline | ✅ exit 1, blames harness, overwrites artifact |
| `Rule.evaluate()` regressed | ✅ exit 1, distinct reason |
| canary template mutation | ✅ shared dict no longer poisonable |

```
ALL TESTS PASS
```

`ruff check services/ tools/` (CI's scope) clean.

## Type of change

- [x] Bug fix
- [ ] New parser (new log source)
- [x] Feature / enhancement (v0.1 scope)
- [x] Docs / infra / developer experience
- [ ] Other:

## Checklist

- [x] One logical change (no unrelated refactors bundled in).
- [x] I did not hand-set `type_uid` — no parser code touched.
- [x] Output still validates against Contract A (OCSF) — no pipeline code touched.
- [x] No real secrets, credentials, or real PII/IPs committed.
- [x] Status claims are accurate — the canary's scope was overstated in the first version of this PR and is corrected here in the code docstring, the CHANGELOG and above, including what it cannot catch.
- [x] No rule files added or changed — the canary is synthetic and lives in the harness, never in `contracts/rules/`.
- [x] By submitting, I agree my contribution is licensed under Apache-2.0 (LICENSE).

Credit: canary suggested by a reader on r/blueteamsec.