### PR TITLE
docs: sync README/CHANGELOG/ADR-001/sigma-convention with recent merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **M7 Track Y — OT inventory-diff detection, end to end**: a new
+  `ot_new_device_on_segment` rule fires on a genuinely new device appearing
+  on an OT segment. `services/ws6-inventory`'s `InventoryStore` now tracks a
+  first-ever sighting of a MAC per tenant, gated behind a per-tenant baseline
+  window (`INVENTORY_BASELINE_SECONDS`, default 1h) so standing the service
+  up against an existing segment populates inventory instead of alerting on
+  every device already there, and durable in SQLite so a restart is never
+  mistaken for the whole segment reappearing. A new bus consumer
+  (`services/ws6-inventory/bus_consumer.py`) closes a gap that predates this
+  feature — `contracts/bus-topics.md` had named WS-6 as `assets.updates`'
+  consumer since Phase 0, and `requirements.txt` had carried the dependency
+  comment since an earlier audit, but nothing had ever implemented it: WS-6
+  now consumes `assets.updates` and republishes an alertable first sighting
+  onto `raw.events`, giving the rule a real producer for the first time.
+  `redis` is opt-in in WS-6's image (only pulled in when `BUS_BACKEND` is
+  set), so the zero-infra HTTP-only path is unaffected. Two independent
+  adversarial reviews returned DO NOT SHIP on the first cut of this work (no
+  baseline, no durable state, unproven tenant isolation, no producer at all)
+  — all fixed; see `SSOT.md`'s M7 Track Y rows for the full history.
+- **Partial SigmaHQ rule importer** (`tools/import_sigma_rules.py`): converts
+  a subset of SigmaHQ's public detection rules into this repo's own rule
+  format — selection sanitization, dict/list/OR selection shapes, condition
+  rewriting (`and`/`or`/`not`), `contains`/`startswith`/`endswith`/`re`
+  modifiers (regex translated to a bounded glob under ADR-005's no-ReDoS
+  constraint, or rejected). Honest about scope: roughly the basic
+  detection/condition layer, an estimated 10-20% of real-world SigmaHQ
+  constructs — full regex fields, additional modifiers, timeframes, and
+  complex condition syntax are still open. Two independent review rounds
+  found and this fixed 5 real bugs, the sharpest being that a Sigma
+  list-selection (OR-of-items) referenced by its original name silently kept
+  only the first branch, and a selection named `and`/`or`/`not` imported
+  cleanly into a syntactically dead condition with no error reported.
+- **Sigma-style `glob` operator** in the rule grammar
+  (`services/ws4-detection/engine.py::_glob_match`, `*`/`?`/`[seq]`/`[!seq]`
+  via `fnmatch`) — the cheap partial step toward Sigma-rule portability;
+  explicitly not a regex layer, so ADR-005's no-ReDoS guarantee is unchanged.
+- **Rule-health / dead-rule watchdog**: `Detector.record_fire()` stamps a
+  real timestamp per rule id on every match; `rule_health_metrics()` renders
+  one gauge per rule that has actually fired (never fabricated as 0 for one
+  that hasn't) on the existing `/metrics/prom` route, closing the gap where
+  a rule proven fireable (`fire_check.py`) could still go silently dead in
+  production with no distinguishable signal from "no attacks happened."
 - **Non-zero rule-count floor** in `eval/attack/fire_check.py` and
   `tools/check_rule_producers.py`: both gates passed while examining **zero
   rules**. Every check in either is vacuously true over an empty set, so a

--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ make e2e      # zero-infra ACCEPTANCE test: SSH brute-force -> real alert (no Do
 make test     # run the full zero-infra contract test suite (no Docker needed)
 make up       # start the stack detached (docker compose up -d)
 make down     # stop the stack and remove volumes
+make ha-up    # OPT-IN: Redis Sentinel (1 primary + 2 replicas + 3 Sentinels) + 3-node OpenSearch HA
+              # profile on top of the default stack (needs REDIS_PASSWORD) -- see
+              # infra/docker-compose.ha.yml's header comment. Default `make up` is unaffected.
+make ha-down  # stop the HA profile and remove its volumes
 ```
 
 ---
@@ -311,9 +315,9 @@ schema (OCSF).
 | WS | Service | Role | v0.1 status |
 |----|---------|------|-------------|
 | 1 | `services/ws1-collectors` | Collect logs → `raw.events` | ✅ |
-| 2 | `services/ws2-normalization` | Parsers → validated OCSF events | ✅ (16 parsers) |
+| 2 | `services/ws2-normalization` | Parsers → validated OCSF events | ✅ (17 parsers) |
 | 3 | `services/ws3-indexer` | Routing + OpenSearch indexing (idempotent) | ✅ |
-| 4 | `services/ws4-detection` | Correlation rules + scoring + windowing | ✅ (27 rules) |
+| 4 | `services/ws4-detection` | Correlation rules + scoring + windowing | ✅ (28 rules) |
 | 5 | `services/ws5-ai` | Triage | ✅ real local-LLM (Ollama) since v0.2, stub fallback |
 | 6 | `services/ws6-inventory` | IP/MAC inventory API (SQLite) | ✅ |
 | 7 | `services/ws7-dashboard` | Alert console | ✅ |

--- a/contracts/sigma-convention.md
+++ b/contracts/sigma-convention.md
@@ -90,6 +90,20 @@ detection:
   layer, not just this operator. A non-string operand or empty/oversized
   (>200 char) pattern fails closed, same discipline as `contains`.
 
+## Importing SigmaHQ rules (M7 follow-up)
+
+`tools/import_sigma_rules.py` converts a real SigmaHQ rule YAML into the shape
+this file describes: selection sanitization, dict/list/OR selection shapes,
+`and`/`or`/`not` condition rewriting, and the `contains`/`startswith`/
+`endswith`/`re` modifiers (`re` translates to a bounded `glob` above, or
+rejects the rule if it can't). Run it with `python tools/import_sigma_rules.py
+<sigma-rule.yml> [out.yml]`; anything it drops or defaults is printed as a
+`[WARN]`, not silently discarded. **Honest scope**: this covers roughly the
+basic detection/condition layer, an estimated 10-20% of real-world SigmaHQ
+constructs — full regex fields, additional modifiers (`base64`, etc.),
+timeframes, references, and more complex condition syntax are not yet
+supported, so this does not make arbitrary SigmaHQ rules importable.
+
 ## Periodicity / beaconing (v0.5, A3)
 
 An optional `siem.periodicity` block on a stateful rule additionally requires

--- a/docs/adr/001-redis-streams-as-the-bus.md
+++ b/docs/adr/001-redis-streams-as-the-bus.md
@@ -38,9 +38,15 @@ is actually built (YAGNI), not before.
 - **Positive:** `BUS_BACKEND=memory` gives the zero-infra contributor loop
   (`make test`, `make e2e`) — no Docker/Redis needed to add a parser or rule.
 - **Trade-off, documented (R-B in the architecture review):** Redis is a
-  single instance in the current (local/air-gapped) deployment tier; there is
-  no HA design yet (Sentinel/cluster) for a future central tier. Conscious
-  scope cut, not an oversight.
+  single instance by default. **Update (F4/HA, 2026-08-05):** an opt-in
+  Sentinel HA profile now exists (`infra/docker-compose.ha.yml`,
+  `_RedisSentinelBus` in `services/shared/bus.py` — 1 primary + 2 replicas +
+  3 Sentinels, `make ha-up`), not the single-instance-only setup this ADR
+  originally described. Cluster (sharding) was still the deliberate non-choice
+  named below; Sentinel was picked because nothing in this workload needs
+  sharding, and Cluster's multi-key restriction would constrain future work
+  for no throughput benefit. The default `docker compose up` path is
+  byte-for-byte unaffected — HA is opt-in, not the new baseline.
 - **Trade-off:** `_MemoryBus` fakes redelivery/DLQ semantics differently than
   `_RedisBus` (no persistent PEL — tests re-create the loop via a re-produce
   pattern). Anything depending on real PEL behavior (XAUTOCLAIM timing,


### PR DESCRIPTION
## Summary
Doc-status sweep after the M7 Track Y (OT inventory-diff + WS-6 bus transport) and Sigma-importer merges:

- **README.md**: parser/rule counts were stale (16/27 -> actual 17/28); `make ha-up`/`ha-down` existed in the Makefile but weren't in README's own command list.
- **CHANGELOG.md**: added `[Unreleased]` entries for rule-health watchdog, Sigma-glob operator, `tools/import_sigma_rules.py`, and the OT inventory-diff feature -- all landed in SSOT.md this session but never got a CHANGELOG entry.
- **contracts/sigma-convention.md**: documents the new Sigma importer next to the `glob` operator it depends on.
- **docs/adr/001-redis-streams-as-the-bus.md**: corrected a stale claim ("no HA design yet") -- PR#46 shipped an opt-in Sentinel HA profile since that line was written. Original trade-off record kept, not erased.

No code changes.

## Test plan
- [x] Grepped for stray merge-conflict markers -- clean
- [x] Cross-checked every changed count against actual repo state (`known_sources()`, `contracts/rules/*.yml` count)