### PR TITLE
chore(deps): bump github/codeql-action init/analyze/upload-sarif to 4.37.8 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           languages: python
           queries: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           languages: python
           queries: security-extended
-      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Dependabot opened three separate PRs (#75 init, #76 analyze, #77 upload-sarif) each bumping ONE of the three `codeql-action` sub-action pins independently. All three were previously pinned to the same SHA (`ff2f1c6...`, v4.37.7); `init` and `analyze` live in `codeql.yml` and must move together -- CodeQL's own post-action step checks the config version `init` wrote against the version `analyze` is running, so landing #75 or #76 alone breaks CI:

```
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.8', but running version '4.37.7'
```

Confirmed on both #75 and #76 (`analyze: fail`, `CodeQL: skipping`). #77 (upload-sarif, a separate workflow/file) is unaffected on its own and already green.

This PR cherry-picks all three Dependabot commits together so `init`/`analyze`/`upload-sarif` land on the same SHA (`db488dd...`, v4.37.8) in one atomic change. Supersedes #75, #76, #77 -- closing those individually with a pointer to this PR once this one is confirmed green.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open(...))"` on both touched workflow files -- valid YAML
- [ ] CI green on this PR (in particular `CodeQL`/`analyze`, the two that were failing individually)