### PR TITLE
chore(dependabot): group github/codeql-action bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,3 +88,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # github/codeql-action ships init/analyze/upload-sarif as separate
+      # dependency references but init and analyze in the SAME workflow MUST
+      # be pinned to the same release -- CodeQL hard-errors otherwise
+      # ("Loaded a configuration file for version X, but running version Y").
+      # Ungrouped, dependabot opened one PR per reference (#84 bumped only
+      # codeql.yml's init, breaking its own analyze step; #85 bumped
+      # scorecard.yml's standalone upload-sarif, which has no init to match
+      # and stayed safe on its own) -- found and fixed 2026-09-02. Grouping
+      # them means future bumps land as one PR that's internally consistent
+      # by construction, not by whoever reviews remembering this constraint.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Summary
- `github/codeql-action`'s `init` and `analyze` steps in the same workflow must be pinned to the same release, or CodeQL hard-errors ("Loaded a configuration file for version X, but running version Y").
- Dependabot currently treats each pinned action reference as an independent dependency, so it can (and did) open a PR that bumps only one of the pair.
- Live-reproduced on PR #84: it bumped `codeql.yml`'s `init` to v4.37.9 and left `analyze` on v4.37.8 — the `analyze` job failed with exactly that error. Fixed on that PR by hand.
- This adds a `groups:` entry so every `github/codeql-action/*` reference bumps together going forward, correct by construction instead of by review vigilance.

## Test plan
- [x] YAML is a config file for Dependabot, not a workflow — no CI job executes it directly; `actionlint`/`gitleaks`/etc. on this PR cover the rest of the diff (none, since only `dependabot.yml` changed).
- [x] Verified against the real failure this fixes: PR #84's `analyze` job errored with "Loaded a configuration file for version '4.37.9', but running version '4.37.8'" before the hand-fix; grouping prevents that class of mismatch on future dependabot-driven bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)